### PR TITLE
EZEE-2150: Added migration command to upgrade Landing Pages created in eZ Platform <= 2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/vendor/
+composer.lock
+phpunit.xml
+.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,42 @@
+<?php
+
+$header = <<<'EOF'
+@copyright Copyright (C) eZ Systems AS. All rights reserved.
+@license For full copyright and license information view LICENSE file distributed with this source code.
+EOF;
+
+return PhpCsFixer\Config::create()
+    ->setRules([
+        '@Symfony' => true,
+        '@Symfony:risky' => true,
+        'concat_space' => ['spacing' => 'one'],
+        'array_syntax' => false,
+        'simplified_null_return' => false,
+        'phpdoc_align' => false,
+        'phpdoc_separation' => false,
+        'phpdoc_to_comment' => false,
+        'cast_spaces' => false,
+        'blank_line_after_opening_tag' => false,
+        'single_blank_line_before_namespace' => false,
+        'phpdoc_annotation_without_dot' => false,
+        'phpdoc_no_alias_tag' => false,
+        'space_after_semicolon' => false,
+        'header_comment' => [
+            'commentType' => 'PHPDoc',
+            'header' => $header,
+            'location' => 'after_open',
+            'separate' => 'top',
+        ],
+        'yoda_style' => false,
+        'no_break_comment' => false,
+    ])
+    ->setRiskyAllowed(true)
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->in(__DIR__)
+            ->exclude([
+                'vendor',
+            ])
+            ->files()->name('*.php')
+    )
+    ;

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,306 @@
+Copyright (C) 1999-2017 eZ Systems AS. All rights reserved.
+This source code is provided under the following license:
+
+
+eZ Trial and Test License Agreement ("eZ TTL") Version 2.0
+
+
+IMPORTANT: Please read the following license agreement carefully.
+
+This license agreement is between eZ systems AS (Norwegian business
+registration no. 981 601 564), a Norwegian company ("Licensor" or "eZ"),
+and a test or trial user ("Licensee" or "you"). By installing all or any
+portion of the software (or authorizing any other person to do so), you
+accept the terms and conditions of this license. If you acquired the
+software without an opportunity to review this license and do not accept
+the license, you must: (a) not use the software and (b) return or delete
+the software, with your certification of deletion, within thirty (30)
+days of the acquire date.
+
+This license agreement is entered into in connection with Licensee's
+participation in testing a new version of Licensor software and is valid
+for 6 months from the date the software was acquired (downloaded).
+
+The parties hereby agree to the following software license terms:
+
+
+1. Definitions
+
+"Licensed Software" means the eZ Publish Enterprise Edition content
+management system or other software product downloaded, ordered or
+otherwise legally acquired (licensed) by Licensee from Licensor (or
+other party authorized by the Licensor) under these terms.
+
+"Licensed Copy" means one sample of the Licensed Software.
+
+"Website" means up to three defined site access configurations (unique
+URLs) that may for instance consist of one site for public use, one site
+for internal use (such as an intranet) and one site for site
+administrator use, communicated an unlimited number of channels
+(such as traditional web, mobile).
+
+2. License grant
+
+2.1 You may
+Licensor grants you a limited, non-exclusive, time limited and
+non-transferable right to:
+(a) install and run the Licensed Copy on the agreed number of Websites
+for internal testing purposes;
+(b) make enhancements, patches, workarounds, bug fixes or other
+modifications (collectively "Licensee Modifications") to the Licensed
+Copy, solely for your internal testing of the Licensed Software, and
+(c) perform presentations based on the Licensed Software, including
+building and presenting sample solutions to your clients or potential
+clients.
+
+Since the license is free of charge, you are obliged to submit Licensee
+Modifications to eZ on a continuous basis to contribution@ez.no as
+contributions, see section 7.1. Such contribution must include a short
+note explaining the Licensee Modification.
+
+Licensee may make a reasonable number of copies of the Licensed Copy as
+required for backup and archival purposes only.
+
+2.2 You may not
+Licensee may use the Licensed Software only as expressly granted in
+section 2.1. Without limiting the foregoing, Licensee may not: (a) use
+or operate the Licensed Software for regular business use; (b) give,
+lease, license, sell, make available, or distribute any part of the
+Licensed Software or Licensee Modifications to any third party, except
+as otherwise expressly permitted herein; (c) use the Licensed Software
+to operate in or as a time-sharing, outsourcing, service bureau,
+application service provider, managed service provider environment or
+similar service directed towards and performed on behalf or for the
+benefit of a third party; (d) copy the Licensed Software onto any public
+or distributed network; or (e) change any rights notices which appear in
+the Licensed Software.
+
+3. Your responsibility
+Except as expressly set forth herein or in a separate written agreement,
+Licensee is the sole responsible for the installation of the Licensed
+Software, its operation, supervision, maintenance, management and
+related training and support. You are also the sole responsible for any
+related installation, maintenance and configuration of computer hardware
+used by the Licensed Software.
+
+4. Price
+You may use the Software free of charge.
+
+5. Audit rights
+During the term of this license and for a three (3) year period
+following its termination, Licensor may conduct periodic reviews of
+Licensee's records relating to its Licensed Software for the purpose of
+verifying Licensee's compliance with this license and any related
+agreements. During this three (3) year period, you are obliged to
+maintain complete and accurate books and other records related to
+software licensing and related payments. Licensor must exercise its
+right of audit upon no fewer than 15 days' prior notice. Licensee will
+provide Licensor with reasonable access and assistance for the audit,
+including reasonable use of available office equipment and space.
+Licensor shall upon request deliver to Licensee a copy of the results of
+any such audit.
+
+6. Termination
+Licensor may terminate this license immediately if you are in breach any
+of its provisions and such breach remains uncured 30 days after receipt
+of notice. In the event that you are or becomes liquidated, dissolved,
+bankrupt or insolvent, whether voluntarily or involuntarily, or is to
+take any action to be so declared, Licensor may terminate this license
+immediately. Upon cancellation or other termination of this license, for
+any reason, you must immediately destroy all copies of the Licensed
+Software, and confirm the destruction within  7 (seven) days. Sections 5
+through 11 shall survive the termination of this license for any reason.
+
+7. Intellectual property rights
+
+7.1 General
+Licensee agrees that the copyright and all other intellectual property
+and proprietary rights of whatever nature in the Licensed Software and
+related documentation are not by this license transferred to you. No
+trademarks of eZ may be used by you without Licensor's express written
+permission. If permission is grated, use must always take place in
+accordance with the applicable Licensor guidelines as they may be
+updated from time to time. For Licensee Modifications, you must, in the
+modified files and in a separate text file, clearly indicate that the
+Licensed Software contains modifications and state their dates.
+
+7.2 Contribution of Licensee Modifications
+To the extent that any contributed Licensee Modifications incorporates
+any element which is subject to any intellectual property right owned by
+Licensee, Licensee hereby grants to eZ an unrestricted, non-exclusive,
+perpetual, royalty-free, world-wide, irrevocable and fully transferable
+license to make, use, sell, offer for sale, reproduce, create
+derivatives of, publish, display, sublicense or otherwise practice such
+intellectual property right.
+
+Regarding any copyrights in Licensee Modifications:
+- You hereby assign to us joint ownership, and to the extent that such
+  assignment is or becomes invalid, ineffective or unenforceable, you
+  hereby grant to us a perpetual, irrevocable, non-exclusive, worldwide,
+  no-charge unrestricted license to exercise all rights under those
+  copyrights. This includes, at our option, the right to sublicense
+  these same rights to third parties through multiple levels of
+  sub-licensees or other licensing arrangements;
+
+- You agree that each of us can do all things in relation to Licensee
+  Modifications as if each of us were sole and independent copyright
+  holders. If one of us makes a derivative work the Licensee
+  Modifications, the one who makes the derivative work (or has it made)
+  will be the sole owner of that derivative work, hereunder make, have
+  made, use, license, offer to license, import, and otherwise transfer
+  your contribution in whole or in part, whether at a charge or at
+  no-charge;
+
+- You agree that neither of us have any duty to consult with, obtain the
+  consent of, pay or render accounts to the other for any use or
+  distribution of the material.
+
+With respect to the Licensee Modifications, you represent that:
+- it is an original work by you and that you can legally grant the
+  rights set out in these terms;
+- it does not to the best of your knowledge violate any third party's
+  copyrights, trademarks, patents or other intellectual property rights.
+
+8. Disclaimer of warranties
+The Licensed Software is licensed "as is," without any warranties
+whatsoever. Licensor expressly disclaims, and licensee expressly waives,
+all warranties, whether express or implied, including warranties of
+merchantability, fitness for a particular purpose, non-infringement,
+system integration, non-interference and accuracy of informational
+content. Licensor does not warrant that the licensed software will meet
+licensee's requirements or that the operation of the licensed software
+will be uninterrupted or error-free, or that errors will be corrected.
+The entire risk of the licensed software's quality and performance is
+with licensee.
+
+9. Indemnification
+Licensee agrees to indemnify and hold Licensor harmless against any
+damage or loss (including reasonable attorneys' fees) related to any
+claim based upon: (a) use of the Licensed Software in a manner
+prohibited under this license or in a manner for which the Licensed
+Software was not designed; (b) Licensee Modifications or changes made by
+Licensee to the Licensed Software (where use of unmodified Licensed
+Software would not infringe); or (c) changes made, or actions taken, by
+Licensor upon Licensee's direct instructions.
+
+10. Limitation of liability
+To the extent permitted by applicable law, licensor shall have no
+liability with respect to its obligations under this license or
+otherwise for direct, consequential, exemplary, special, indirect,
+incidental or punitive damages, including any lost profits or lost
+savings (whether resulting from impaired or lost data, software or
+computer failure or any other cause), even if it has been advised of the
+possibility of such damages.
+
+This limitation of liability applies to any default, including breach of
+contract, breach of warranty, negligence, misrepresentations and other
+torts. The parties agree that the remedies and limitations herein
+allocate the risks between the parties as authorized by applicable laws.
+The license fee (non) is set in reliance upon this allocation of risk
+and the exclusion of certain damages as set forth in this license.
+
+11. Miscellaneous
+
+11.1 Interpretation
+Failure by Licensor to exercise any right or remedy does not signify
+acceptance of the event giving rise to such right or remedy, or loss of
+such right. No claim arising out of this License may be brought by you
+more than one year after the cause of the claim arose.
+
+If any part of this license is held by a court of competent jurisdiction
+to be illegal or unenforceable, the validity or enforceability of the
+remainder of this License shall not be affected and such provision shall
+be deemed modified to the minimum extent necessary to make such
+provision consistent with applicable law. In its modified form, such
+provision shall be enforceable and enforced.
+
+11.2 Termination for patent action
+This license shall terminate automatically and you may no longer
+exercise any of the rights granted to you by this license as of the date
+you commence an action, including a cross-claim or counterclaim, against
+eZ, an eZ partner or other licensee of eZ software alleging that the
+Software infringes a patent.
+
+11.3 Assignment
+Without the prior written consent of Licensor, you may not assign,
+sublicense or otherwise transfer this license or its rights or
+obligations under this license to any person or party, whether by
+operation of law or otherwise. Any attempt by you to assign this license
+without Licensor's prior written consent is void and will terminate the
+license without further notice.
+
+11.4 Governing law
+This License shall be deemed to have been executed in Norway and shall
+be governed by the laws of Norway, without regard to any conflict of law
+provisions.
+
+11.5 Disputes and legal venue
+The parties shall first attempt to resolve any disputes, controversies
+or claims (collectively "Dispute") arising out of or relating to this
+license through amicable discussions and negotiations.
+
+If a Dispute cannot be resolved amicably between the parties, such
+Dispute shall be referred to Oslo City Court as mandatory legal venue.
+However, if you are located in a country that does not have a bilateral
+or multilateral ruling enforcement treaty with Norway, the Dispute shall
+be referred to and finally determined by arbitration administered by the
+World Intellectual Property Organization (WIPO) Arbitration and
+Mediation Centre in accordance with the WIPO Arbitration Rules.
+
+The place of arbitration shall be in Oslo, Norway. The arbitrator - of
+which there shall be only one - shall be bound by the provisions of this
+license and base the award on Norwegian substantive law and judicial
+precedent. The parties agree that the arbitrator shall have the power to
+decide all matters, including arbitrability, and to award any remedies,
+including attorneys' fees, costs and equitable relief, available under
+applicable law. Either party may enforce any judgment rendered by the
+arbitrator in any court of competent jurisdiction. The parties further
+agree and acknowledge that arbitration shall be the sole and final
+remedy for any dispute between the parties. All proceedings and
+documents shall remain strictly confidential.
+
+In no event shall the United Nations Convention on Contracts for the
+International Sale of Goods apply to, or govern, this License.
+
+11.6 Notices
+Any notice under this license shall be delivered and addressed to
+Licensee at the address provided to Licensor (or authorized
+representative) at the time of order, and to Licensor at
+
+Attn: Software Licensing Dept/CLA,
+eZ Systems AS,
+Klostergata 30,
+N-3732 Skien,
+Norway
+
+Notices are deemed received by any party: (a) on the day given, if
+personally delivered or if sent by confirmed facsimile transmission,
+receipt verified; (b) on the third day after deposit, if mailed by
+certified, first class, postage prepaid, return receipt requested mail,
+or by reputable, expedited overnight courier; or (c) on the fifth day
+after deposit, if sent by reputable, expedited international courier.
+
+Either party may change its address for notice purposes upon notice in
+accordance with this section.
+
+11.7 Export law assurances
+Licensee is responsible for complying with any applicable local laws,
+including but not limited to export and import regulations.
+
+11.8 Entire agreement
+This license comprises the entire agreement, and supersedes and merges
+all prior proposals, understandings and agreements, oral and written,
+between the parties relating to the subject matter of this license.
+Licensor's acceptance of any document shall not be construed as an
+acceptance of provisions which are in any way in conflict or
+inconsistent with, or in addition to, this license, unless such terms
+are separately and specifically accepted in writing by an authorized
+officer of Licensor.
+
+11.9 Update of terms
+The Licensor may from time to time issue new versions of this license.
+Unless you within 30 days from when you were first made aware or should
+have become aware of the new license has not made reservations directed
+at Licensor in writing, such new version of the license shall be deemed
+as accepted by you.
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# ezplatform-page-migration
+# ezsystems/ezplatform-page-migration

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,40 @@
+{
+    "name": "ezsystems/ezplatform-page-migration",
+    "description": "eZ Platform Page FieldType Migration Tool",
+    "license": "TTL-2.0",
+    "type": "ezplatform-bundle",
+    "authors": [
+        {
+            "name": "eZ Systems",
+            "email": "dev-team@ez.no"
+        }
+    ],
+    "repositories": [
+        { "type": "composer", "url": "https://updates.ez.no/ttl" }
+    ],
+    "require": {
+        "php": ">=7.1",
+        "ezsystems/ezpublish-kernel": "^7.2",
+        "ezsystems/ezplatform-page-fieldtype": "^1.0",
+        "symfony/symfony": "^3.4.0",
+        "doctrine/dbal": "^2.7"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^7.1",
+        "friendsofphp/php-cs-fixer": "^2.11"
+    },
+    "autoload": {
+        "psr-4": {
+            "EzSystems\\EzPlatformPageMigration\\": "src/lib/",
+            "EzSystems\\EzPlatformPageMigrationBundle\\": "src/bundle/"
+        }
+    },
+    "scripts": {
+        "fix-cs": "@php ./vendor/bin/php-cs-fixer fix -v --show-progress=estimating"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
+    }
+}

--- a/src/bundle/Command/MigrateDataCommand.php
+++ b/src/bundle/Command/MigrateDataCommand.php
@@ -1,0 +1,329 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformPageMigrationBundle\Command;
+
+use Doctrine\DBAL\Connection;
+use Exception;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry;
+use eZ\Publish\Core\Persistence\Legacy\Content\Gateway as ContentGateway;
+use eZ\Publish\Core\Persistence\Legacy\Content\Handler as ContentHandler;
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
+use EzSystems\EzPlatformPageMigration\Converter\FieldValueConverter;
+use EzSystems\EzPlatformPageFieldType\Exception\BlockDefinitionNotFoundException;
+use EzSystems\EzPlatformPageFieldType\Exception\PageNotFoundException;
+use EzSystems\EzPlatformPageFieldType\FieldType\LandingPage\Model\Page;
+use EzSystems\EzPlatformPageFieldType\FieldType\Page\Storage\Gateway;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use function count;
+
+class MigrateDataCommand extends Command
+{
+    /** @var string */
+    protected static $defaultName = 'ezplatform:page:migrate';
+
+    /** @var \eZ\Publish\Core\Persistence\Legacy\Content\Handler */
+    protected $contentHandler;
+
+    /** @var \eZ\Publish\SPI\Persistence\Content\Type\Handler */
+    protected $contentTypeHandler;
+
+    /** @var \EzSystems\EzPlatformPageMigration\Converter\FieldValueConverter */
+    private $legacyConverter;
+
+    /** @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry */
+    private $converterRegistry;
+
+    /** @var \EzSystems\EzPlatformPageFieldType\FieldType\Page\Storage\Gateway */
+    private $pageGateway;
+
+    /** @var \eZ\Publish\Core\Persistence\Legacy\Content\Gateway */
+    private $contentGateway;
+
+    /** @var \Doctrine\DBAL\Connection */
+    private $connection;
+
+    /**
+     * @param null|string $name
+     * @param \EzSystems\EzPlatformPageMigration\Converter\FieldValueConverter $legacyConverter
+     * @param \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry $converterRegistry
+     * @param \eZ\Publish\Core\Persistence\Legacy\Content\Handler $contentHandler
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
+     * @param \eZ\Publish\Core\Persistence\Legacy\Content\Gateway $contentGateway
+     * @param \EzSystems\EzPlatformPageFieldType\FieldType\Page\Storage\Gateway $pageGateway
+     * @param \Doctrine\DBAL\Connection $connection
+     */
+    public function __construct(
+        ?string $name = null,
+        FieldValueConverter $legacyConverter,
+        ConverterRegistry $converterRegistry,
+        ContentHandler $contentHandler,
+        ContentTypeHandler $contentTypeHandler,
+        ContentGateway $contentGateway,
+        Gateway $pageGateway,
+        Connection $connection
+    ) {
+        parent::__construct($name);
+
+        $this->legacyConverter = $legacyConverter;
+        $this->converterRegistry = $converterRegistry;
+        $this->pageGateway = $pageGateway;
+        $this->contentHandler = $contentHandler;
+        $this->contentTypeHandler = $contentTypeHandler;
+        $this->contentGateway = $contentGateway;
+        $this->connection = $connection;
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setDescription('Migrate Landing Pages from eZ Platform <= 2.1')
+            ->setHelp(<<<'EOF'
+            
+<info>%command.name%</info> runs a migration process for Landing Pages created in previous versions of eZ Platform. 
+
+<warning>During the script execution the database should not be modified.
+
+To avoid surprises you are advised to create a backup or execute a dry run:
+ 
+    %command.name% --dry-run
+    
+before proceeding with the actual update.</warning>
+
+Since this script can potentially run for a very long time, to avoid memory
+exhaustion, run it in production environment using the <info>--env=prod</info> switch.
+
+If you configuration uses multiple repositories, 
+you have to run the comand multiple times 
+with different siteaccesses using <info>--siteaccess</info> switch.
+
+EOF
+            )
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'When specified, changes are _NOT_ persisted to database.')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $isDryRun = $input->getOption('dry-run');
+        $io = new SymfonyStyle($input, $output);
+
+        if ($isDryRun) {
+            $io->note('<info>--dry-run</info> switch activated. Operation won\'t be persisted to the database.');
+        }
+
+        $io->warning('You are about to run data migration process for Landing Pages. This operation cannot be reverted.');
+
+        // inject custom field value converter to transform XML into Page object
+        $converter = $this->converterRegistry->getConverter('ezlandingpage');
+        $this->converterRegistry->register('ezlandingpage', $this->legacyConverter);
+
+        $contentIds = $this->findLandingPages();
+
+        if (empty($contentIds)) {
+            $io->writeln('Found 0 content items. Exiting...');
+
+            return;
+        }
+
+        $question = sprintf('Found %d content items. Do you want to continue?', count($contentIds));
+        if (!$io->confirm($question, false)) {
+            return;
+        }
+
+        /** @var \eZ\Publish\SPI\Persistence\Content\VersionInfo[] $spiVersions */
+        $spiVersions = array_merge(...array_map([$this->contentHandler, 'listVersions'], $contentIds));
+
+        $io->newLine();
+
+        if (!$isDryRun) {
+            $this->connection->beginTransaction();
+        }
+
+        foreach ($spiVersions as $spiVersionInfo) {
+            try {
+                $content = $this->contentHandler->load(
+                    $spiVersionInfo->contentInfo->id,
+                    $spiVersionInfo->versionNo,
+                    $spiVersionInfo->languageCodes
+                );
+            } catch (BlockDefinitionNotFoundException $e) {
+                $io->error(sprintf('Cannot find block definition for block type "%s".', $e->getBlockType()));
+                $io->newLine();
+
+                if (!$io->confirm('Do you want to ignore unknown blocks in migrated Landing Pages?', true)) {
+                    if (!$isDryRun) {
+                        $this->connection->rollBack();
+                    }
+
+                    return;
+                }
+
+                $this->legacyConverter->setIgnoreUnknownBlocks(true);
+                $content = $this->contentHandler->load(
+                    $spiVersionInfo->contentInfo->id,
+                    $spiVersionInfo->versionNo,
+                    $spiVersionInfo->languageCodes
+                );
+            }
+
+            $contentId = (int) $spiVersionInfo->contentInfo->id;
+            $versionNo = (int) $spiVersionInfo->versionNo;
+
+            foreach ($content->fields as $field) {
+                if (!$this->isPageField($field)) {
+                    continue;
+                }
+
+                $languageCode = $field->languageCode;
+                $contentName = current($spiVersionInfo->names);
+                $pageIdentifierString = sprintf(
+                    '"%s" [contentId: %s, versionNo: %s, languageCode: %s]',
+                    $contentName,
+                    $contentId,
+                    $versionNo,
+                    $languageCode
+                );
+
+                $io->newLine();
+                $io->section($pageIdentifierString);
+
+                if ($this->doesPageExist($contentId, $versionNo, $languageCode)) {
+                    $io->note('Page has already been migrated. Skipping...');
+                    continue;
+                }
+
+                $page = $field->value->externalData;
+
+                try {
+                    if (!$isDryRun) {
+                        $this->insertPage($contentId, $versionNo, $languageCode, $page);
+                    }
+                } catch (Exception $e) {
+                    $io->error(sprintf('Cannot save Page due to the error: %s', $e->getMessage()));
+                    continue;
+                }
+
+                $io->success('Page has been successfully migrated');
+            }
+        }
+
+        if (!$isDryRun) {
+            $this->connection->commit();
+        }
+
+        // bring back old converter
+        $this->converterRegistry->register('ezlandingpage', $converter);
+    }
+
+    /**
+     * @return int[]
+     */
+    protected function findLandingPages(): array
+    {
+        $contentType = $this->contentTypeHandler->loadByIdentifier('landing_page');
+        $contentIds = $this->contentGateway->getContentIdsByContentTypeId($contentType->id);
+
+        return $contentIds;
+    }
+
+    /**
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     *
+     * @return bool
+     */
+    private function isPageField(Field $field): bool
+    {
+        return 'ezlandingpage' === $field->type;
+    }
+
+    /**
+     * @param int $contentId
+     * @param int $versionNo
+     * @param string $languageCode
+     *
+     * @return bool
+     */
+    private function doesPageExist(int $contentId, int $versionNo, string $languageCode): bool
+    {
+        try {
+            $this->pageGateway->loadPageByContentId($contentId, $versionNo, $languageCode);
+        } catch (PageNotFoundException $e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param int $contentId
+     * @param int $versionNo
+     * @param string $languageCode
+     * @param \EzSystems\EzPlatformPageFieldType\FieldType\LandingPage\Model\Page $page
+     */
+    private function insertPage(
+        int $contentId,
+        int $versionNo,
+        string $languageCode,
+        Page $page
+    ): void {
+        $pageId = $this->pageGateway->insertPage(
+            $contentId,
+            $versionNo,
+            $languageCode,
+            $page->getLayout()
+        );
+
+        foreach ($page->getZones() as $zone) {
+            $zoneId = $this->pageGateway->insertZone($zone->getName());
+
+            foreach ($zone->getBlocks() as $blockValue) {
+                $blockId = $this->pageGateway->insertBlock(
+                    $blockValue->getType(),
+                    $blockValue->getName(),
+                    $blockValue->getView()
+                );
+                $this->pageGateway->insertBlockDesign(
+                    $blockId,
+                    $blockValue->getStyle(),
+                    $blockValue->getCompiled(),
+                    $blockValue->getClass()
+                );
+                $this->pageGateway->insertBlockVisibility(
+                    $blockId,
+                    null !== $blockValue->getSince()
+                        ? $blockValue->getSince()->getTimestamp()
+                        : null,
+                    null !== $blockValue->getTill()
+                        ? $blockValue->getTill()->getTimestamp()
+                        : null
+                );
+
+                foreach ($blockValue->getAttributes() as $attribute) {
+                    $attributeId = $this->pageGateway->insertAttribute(
+                        $attribute->getName(),
+                        $attribute->getValue()
+                    );
+                    $this->pageGateway->assignAttributeToBlock($attributeId, $blockId);
+                }
+
+                $this->pageGateway->assignBlockToZone($blockId, $zoneId);
+            }
+
+            $this->pageGateway->assignZoneToPage($zoneId, $pageId);
+        }
+    }
+}

--- a/src/bundle/DependencyInjection/Compiler/AttributeConverterCompilerPass.php
+++ b/src/bundle/DependencyInjection/Compiler/AttributeConverterCompilerPass.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformPageMigrationBundle\DependencyInjection\Compiler;
+
+use EzSystems\EzPlatformPageMigration\Converter\AttributeConverter\ConverterRegistry;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class AttributeConverterCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has(ConverterRegistry::class)) {
+            return;
+        }
+
+        $registry = $container->findDefinition(ConverterRegistry::class);
+        $converterDefinitions = $container->findTaggedServiceIds('ezplatform.fieldtype.ezlandingpage.migration.attribute.converter');
+
+        foreach ($converterDefinitions as $id => $tags) {
+            foreach ($tags as $attributes) {
+                $registry->addMethodCall('addConverter', [$attributes['block_type'], new Reference($id)]);
+            }
+        }
+    }
+}

--- a/src/bundle/DependencyInjection/EzPlatformPageMigrationExtension.php
+++ b/src/bundle/DependencyInjection/EzPlatformPageMigrationExtension.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformPageMigrationBundle\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+/**
+ * This is the class that loads and manages your bundle configuration.
+ *
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
+ */
+class EzPlatformPageMigrationExtension extends Extension
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Exception
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader->load('services.yml');
+    }
+}

--- a/src/bundle/EzPlatformPageMigrationBundle.php
+++ b/src/bundle/EzPlatformPageMigrationBundle.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformPageMigrationBundle;
+
+use EzSystems\EzPlatformPageMigrationBundle\DependencyInjection\Compiler\AttributeConverterCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class EzPlatformPageMigrationBundle extends Bundle
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container): void
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new AttributeConverterCompilerPass());
+    }
+}

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -1,0 +1,38 @@
+services:
+    _defaults:
+        autoconfigure: true
+        autowire: true
+        public: true
+
+    EzSystems\EzPlatformPageMigrationBundle\Command\MigrateDataCommand:
+        arguments:
+            $contentHandler: '@ezpublish.spi.persistence.legacy.content.handler'
+            $contentGateway: '@ezpublish.persistence.legacy.content.gateway'
+            $contentTypeHandler: '@ezpublish.spi.persistence.legacy.content_type.handler'
+            $converterRegistry: '@ezpublish.persistence.legacy.field_value_converter.registry'
+            $pageGateway: '@EzSystems\EzPlatformPageFieldType\FieldType\Page\Storage\DoctrineGateway'
+        tags:
+            - { name: 'console.command', command: 'ezplatform:page:migrate' }
+
+    EzSystems\EzPlatformPageMigration\Converter\AttributeConverter\DefaultConverter:
+        tags:
+            - { name: 'ezplatform.fieldtype.ezlandingpage.migration.attribute.converter', block_type: 'tag'}
+            - { name: 'ezplatform.fieldtype.ezlandingpage.migration.attribute.converter', block_type: 'contentlist'}
+            - { name: 'ezplatform.fieldtype.ezlandingpage.migration.attribute.converter', block_type: 'embed'}
+            - { name: 'ezplatform.fieldtype.ezlandingpage.migration.attribute.converter', block_type: 'banner'}
+            - { name: 'ezplatform.fieldtype.ezlandingpage.migration.attribute.converter', block_type: 'gallery'}
+            - { name: 'ezplatform.fieldtype.ezlandingpage.migration.attribute.converter', block_type: 'video'}
+            - { name: 'ezplatform.fieldtype.ezlandingpage.migration.attribute.converter', block_type: 'rss'}
+
+    EzSystems\EzPlatformPageMigration\Converter\AttributeConverter\CollectionConverter:
+        tags:
+            - { name: 'ezplatform.fieldtype.ezlandingpage.migration.attribute.converter', block_type: 'collection'}
+
+    EzSystems\EzPlatformPageMigration\Converter\AttributeConverter\ConverterRegistry: ~
+
+    EzSystems\EzPlatformPageMigration\Converter\AttributeConverter\XmlProcessor: ~
+
+    EzSystems\EzPlatformPageMigration\Converter\FieldValueConverter: ~
+
+    EzSystems\EzPlatformPageMigration\Page\PageFactory: ~
+

--- a/src/lib/Converter/AttributeConverter/CollectionConverter.php
+++ b/src/lib/Converter/AttributeConverter/CollectionConverter.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformPageMigration\Converter\AttributeConverter;
+
+use DOMNode;
+use EzSystems\EzPlatformPageFieldType\FieldType\LandingPage\Model\Attribute;
+use EzSystems\EzPlatformPageFieldType\FieldType\Page\Block\Definition\BlockDefinition;
+
+class CollectionConverter implements ConverterInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function convert(
+        BlockDefinition $blockDefinition,
+        DOMNode $node
+    ): array {
+        $locationIds = [];
+        /** @var \DOMElement $childElement */
+        foreach ($node->childNodes as $childElement) {
+            if ('locationlist' !== $childElement->nodeName) {
+                continue;
+            }
+
+            foreach ($childElement->getElementsByTagName('locationId') as $locationIdElement) {
+                $locationIds[] = $locationIdElement->nodeValue;
+            }
+        }
+
+        $attributes[] = new Attribute('', 'locationlist', implode(',', $locationIds));
+
+        return $attributes;
+    }
+}

--- a/src/lib/Converter/AttributeConverter/ConverterInterface.php
+++ b/src/lib/Converter/AttributeConverter/ConverterInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformPageMigration\Converter\AttributeConverter;
+
+use DOMNode;
+use EzSystems\EzPlatformPageFieldType\FieldType\Page\Block\Definition\BlockDefinition;
+
+interface ConverterInterface
+{
+    /**
+     * Converts $node to Attribute objects and attaches them to the $objectStorage.
+     *
+     * @param \EzSystems\EzPlatformPageFieldType\FieldType\Page\Block\Definition\BlockDefinition $blockDefinition
+     * @param \DOMNode $node
+     *
+     * @return \EzSystems\EzPlatformPageFieldType\FieldType\LandingPage\Model\Attribute[]
+     */
+    public function convert(BlockDefinition $blockDefinition, DOMNode $node): array;
+}

--- a/src/lib/Converter/AttributeConverter/ConverterRegistry.php
+++ b/src/lib/Converter/AttributeConverter/ConverterRegistry.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformPageMigration\Converter\AttributeConverter;
+
+class ConverterRegistry
+{
+    /** @var \EzSystems\EzPlatformPageMigration\Converter\AttributeConverter\ConverterInterface[] */
+    private $converters;
+
+    /**
+     * @param \EzSystems\EzPlatformPageMigration\Converter\AttributeConverter\ConverterInterface[]|iterable $converters
+     */
+    public function __construct(array $converters = [])
+    {
+        $this->converters = $converters;
+    }
+
+    /**
+     * @param \EzSystems\EzPlatformPageMigration\Converter\AttributeConverter\ConverterInterface[] $converters
+     */
+    public function setConverters(array $converters): void
+    {
+        $this->converters = $converters;
+    }
+
+    /**
+     * @return \EzSystems\EzPlatformPageMigration\Converter\AttributeConverter\ConverterInterface[]
+     */
+    public function getConverters(): array
+    {
+        return $this->converters;
+    }
+
+    /**
+     * @param string $blockTypeIdentifier
+     * @param \EzSystems\EzPlatformPageMigration\Converter\AttributeConverter\ConverterInterface $converter
+     */
+    public function addConverter(string $blockTypeIdentifier, ConverterInterface $converter): void
+    {
+        $this->converters[$blockTypeIdentifier] = $converter;
+    }
+
+    /**
+     * @param string $blockTypeIdentifier
+     *
+     * @return \EzSystems\EzPlatformPageMigration\Converter\AttributeConverter\ConverterInterface|null
+     */
+    public function getConverter(string $blockTypeIdentifier): ?ConverterInterface
+    {
+        if (isset($this->converters[$blockTypeIdentifier])) {
+            return $this->converters[$blockTypeIdentifier];
+        }
+
+        return null;
+    }
+}

--- a/src/lib/Converter/AttributeConverter/DefaultConverter.php
+++ b/src/lib/Converter/AttributeConverter/DefaultConverter.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformPageMigration\Converter\AttributeConverter;
+
+use DOMNode;
+use EzSystems\EzPlatformPageFieldType\FieldType\LandingPage\Model\Attribute;
+use EzSystems\EzPlatformPageFieldType\FieldType\Page\Block\Definition\BlockDefinition;
+
+class DefaultConverter implements ConverterInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function convert(
+        BlockDefinition $blockDefinition,
+        DOMNode $node
+    ): array {
+        $attributes = [];
+        /** @var \DOMElement $childElement */
+        foreach ($node->childNodes as $childElement) {
+            $attributes[] = new Attribute(
+                '',
+                $childElement->getAttribute('name'),
+                $childElement->nodeValue
+            );
+        }
+
+        return $attributes;
+    }
+}

--- a/src/lib/Converter/AttributeConverter/XmlProcessor.php
+++ b/src/lib/Converter/AttributeConverter/XmlProcessor.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformPageMigration\Converter\AttributeConverter;
+
+use DOMNode;
+use EzSystems\EzPlatformPageFieldType\FieldType\Page\Block\Definition\BlockDefinition;
+
+class XmlProcessor
+{
+    /** @var \EzSystems\EzPlatformPageMigration\Converter\AttributeConverter\ConverterRegistry */
+    private $registry;
+
+    /**
+     * @param \EzSystems\EzPlatformPageMigration\Converter\AttributeConverter\ConverterRegistry $registry
+     */
+    public function __construct(ConverterRegistry $registry)
+    {
+        $this->registry = $registry;
+    }
+
+    /**
+     * @param \EzSystems\EzPlatformPageFieldType\FieldType\Page\Block\Definition\BlockDefinition $blockDefinition
+     * @param \DOMNode $node
+     *
+     * @return \EzSystems\EzPlatformPageFieldType\FieldType\LandingPage\Model\Attribute[]
+     */
+    public function processAttributes(BlockDefinition $blockDefinition, DOMNode $node): array
+    {
+        $converter = $this->registry->getConverter($blockDefinition->getIdentifier());
+
+        if (null === $converter) {
+            return [];
+        }
+
+        return $converter->convert($blockDefinition, $node);
+    }
+}

--- a/src/lib/Converter/FieldValueConverter.php
+++ b/src/lib/Converter/FieldValueConverter.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformPageMigration\Converter;
+
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
+use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
+use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
+use eZ\Publish\SPI\Persistence\Content\FieldValue;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
+use EzSystems\EzPlatformPageFieldType\FieldType\LandingPage\Type;
+use EzSystems\EzPlatformPageMigration\Page\PageFactory;
+
+/**
+ * Converter for field values in legacy storage.
+ */
+class FieldValueConverter implements Converter
+{
+    /** @var \EzSystems\EzPlatformPageMigration\Page\PageFactory */
+    private $pageFactory;
+
+    /** @var \EzSystems\EzPlatformPageFieldType\FieldType\LandingPage\Type */
+    private $pageFieldType;
+
+    /** @var bool */
+    private $ignoreUnknownBlocks;
+
+    /**
+     * @param \EzSystems\EzPlatformPageMigration\Page\PageFactory $pageFactory
+     * @param \EzSystems\EzPlatformPageFieldType\FieldType\LandingPage\Type $pageFieldType
+     * @param bool $ignoreUnknownBlocks
+     */
+    public function __construct(PageFactory $pageFactory, Type $pageFieldType, bool $ignoreUnknownBlocks = false)
+    {
+        $this->pageFactory = $pageFactory;
+        $this->pageFieldType = $pageFieldType;
+        $this->ignoreUnknownBlocks = $ignoreUnknownBlocks;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toStorageValue(FieldValue $value, StorageFieldValue $storageFieldValue)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Exception
+     */
+    public function toFieldValue(StorageFieldValue $value, FieldValue $fieldValue)
+    {
+        $this->pageFactory->setIgnoreUnknownBlocks($this->shouldIgnoreUnknownBlocks());
+
+        $fieldValue->externalData = null !== $value->dataText
+            ? $this->pageFactory->fromXml($value->dataText)
+            : $this->pageFieldType->getEmptyValue()->getPage();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toStorageFieldDefinition(FieldDefinition $fieldDef, StorageFieldDefinition $storageDef)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toFieldDefinition(StorageFieldDefinition $storageDef, FieldDefinition $fieldDef)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIndexColumn()
+    {
+        return false;
+    }
+
+    /**
+     * @return bool
+     */
+    public function shouldIgnoreUnknownBlocks(): bool
+    {
+        return $this->ignoreUnknownBlocks;
+    }
+
+    /**
+     * @param bool $ignoreUnknownBlocks
+     */
+    public function setIgnoreUnknownBlocks(bool $ignoreUnknownBlocks): void
+    {
+        $this->ignoreUnknownBlocks = $ignoreUnknownBlocks;
+    }
+}

--- a/src/lib/Page/PageFactory.php
+++ b/src/lib/Page/PageFactory.php
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformPageMigration\Page;
+
+use EzSystems\EzPlatformPageFieldType\Exception\ZoneNotFoundException;
+use EzSystems\EzPlatformPageFieldType\FieldType\LandingPage\Model\BlockValue;
+use EzSystems\EzPlatformPageFieldType\FieldType\LandingPage\Model\Page;
+use EzSystems\EzPlatformPageFieldType\FieldType\LandingPage\Model\Zone;
+use EzSystems\EzPlatformPageFieldType\FieldType\Page\Block\Definition\BlockAttributeDefinition;
+use EzSystems\EzPlatformPageFieldType\FieldType\Page\Block\Definition\BlockDefinitionFactory;
+use EzSystems\EzPlatformPageFieldType\Registry\LayoutDefinitionRegistry;
+use EzSystems\EzPlatformPageMigration\Converter\AttributeConverter\XmlProcessor;
+use function in_array;
+
+class PageFactory
+{
+    /** @var \EzSystems\EzPlatformPageFieldType\Registry\LayoutDefinitionRegistry */
+    private $layoutDefinitionRegistry;
+
+    /** @var \EzSystems\EzPlatformPageFieldType\FieldType\Page\Block\Definition\BlockDefinitionFactory */
+    private $blockDefinitionFactory;
+
+    /** @var \EzSystems\EzPlatformPageMigration\Converter\AttributeConverter\XmlProcessor */
+    private $xmlProcessor;
+
+    /** @var bool */
+    private $ignoreUnknownBlocks;
+
+    /**
+     * @param \EzSystems\EzPlatformPageFieldType\Registry\LayoutDefinitionRegistry $layoutDefinitionRegistry
+     * @param \EzSystems\EzPlatformPageFieldType\FieldType\Page\Block\Definition\BlockDefinitionFactory $blockDefinitionFactory
+     * @param \EzSystems\EzPlatformPageMigration\Converter\AttributeConverter\XmlProcessor $xmlProcessor
+     * @param bool $ignoreUnknownBlocks
+     */
+    public function __construct(
+        LayoutDefinitionRegistry $layoutDefinitionRegistry,
+        BlockDefinitionFactory $blockDefinitionFactory,
+        XmlProcessor $xmlProcessor,
+        bool $ignoreUnknownBlocks = false
+    ) {
+        $this->layoutDefinitionRegistry = $layoutDefinitionRegistry;
+        $this->blockDefinitionFactory = $blockDefinitionFactory;
+        $this->xmlProcessor = $xmlProcessor;
+    }
+
+    /**
+     * @param string $xml
+     *
+     * @return \EzSystems\EzPlatformPageFieldType\FieldType\LandingPage\Model\Page
+     *
+     * @throws \Exception
+     */
+    public function fromXml(string $xml): Page
+    {
+        $document = new \DOMDocument();
+        $zones = [];
+        $blocks = [];
+
+        $document->loadXML($xml);
+        $document->normalizeDocument();
+
+        $pageElement = $document->documentElement;
+        $pageLayout = $pageElement->getAttribute('layout');
+
+        $layoutDefinition = $this->layoutDefinitionRegistry->getLayoutDefinitionById($pageLayout);
+        $layoutDefinitionZoneIds = array_keys($layoutDefinition->getZones());
+
+        $zonesElement = $pageElement->getElementsByTagName('zones')->item(0);
+
+        foreach ($zonesElement->getElementsByTagName('zone') as $index => $zoneElement) {
+            $zoneId = $zoneElement->getAttribute('id');
+
+            if (!in_array($zoneId, $layoutDefinitionZoneIds, true) && !isset($layoutDefinitionZoneIds[$index])) {
+                throw new ZoneNotFoundException($layoutDefinition);
+            }
+
+            $zoneName = $zoneElement->getAttribute('name');
+
+            $blocksElement = $zoneElement->getElementsByTagName('blocks')->item(0);
+
+            foreach ($blocksElement->getElementsByTagName('block') as $blockElement) {
+                $blockId = $blockElement->getAttribute('id');
+                $blockType = $blockElement->getAttribute('type');
+                $blockView = $blockElement->getAttribute('view');
+
+                if (
+                    $this->shouldIgnoreUnknownBlocks()
+                    && !$this->blockDefinitionFactory->hasBlockDefinition($blockType)
+                ) {
+                    continue;
+                }
+
+                $blockDefinition = $this->blockDefinitionFactory->getBlockDefinition($blockType);
+
+                $attributes = $this->xmlProcessor->processAttributes(
+                    $blockDefinition,
+                    $blockElement->getElementsByTagName('attributes')->item(0)
+                );
+
+                $name = $blockElement->hasAttribute('name')
+                    ? $blockElement->getAttribute('name')
+                    : '';
+
+                $block = new BlockValue(
+                    $blockId,
+                    $blockType,
+                    $name,
+                    $blockView,
+                    '',
+                    '',
+                    '',
+                    null,
+                    null,
+                    $attributes
+                );
+
+                $blocks[] = $block;
+            }
+
+            $zones[] = new Zone('', $zoneName, $blocks);
+            $blocks = [];
+        }
+
+        return new Page($pageLayout, $zones);
+    }
+
+    /**
+     * @return bool
+     */
+    public function shouldIgnoreUnknownBlocks(): bool
+    {
+        return $this->ignoreUnknownBlocks;
+    }
+
+    /**
+     * @param bool $ignoreUnknownBlocks
+     */
+    public function setIgnoreUnknownBlocks(bool $ignoreUnknownBlocks): void
+    {
+        $this->ignoreUnknownBlocks = $ignoreUnknownBlocks;
+    }
+
+    /**
+     * @param \EzSystems\EzPlatformPageFieldType\FieldType\Page\Block\Definition\BlockAttributeDefinition[] $attributes
+     *
+     * @return string[]
+     */
+    protected function getAttributeNames(array $attributes): array
+    {
+        return array_map(
+            function (BlockAttributeDefinition $blockAttributeDefinition) {
+                return $blockAttributeDefinition->getIdentifier();
+            },
+            $attributes
+        );
+    }
+}


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZEE-2150
> Requires: https://github.com/ezsystems/ezplatform-page-fieldtype/pull/31

![image](https://user-images.githubusercontent.com/10212760/42942925-ac96affe-8b61-11e8-9d1c-554200e18372.png)

# Description
This PR provides CLI `ezplatform:page:migration` command migrating Landing Pages created in eZ Platform 1.x, 2.0 and 2.1 to the new storage adapted in 2.2 release.

# Prerequisites
- You have to create Page Builder database tables first. Please refer to https://doc.ezplatform.com/en/2.2/releases/updating_ez_platform/ for the instruction and SQL script.
- Code has been already migrated to 2.2+.

# Migration steps:
1. `composer require ezsystems/ezplatform-page-migration`
2. Add bundle to `app/AppKernel.php`: `new EzSystems\EzPlatformPageMigrationBundle\EzPlatformPageMigrationBundle(),`
3. Run command: `bin/console ezplatform:page:migrate`

# Command usage
It works as a standard Symfony Console command: `bin/console ezplatform:page:migrate`. You can use `--siteaccess` switch if you need to migrate data on different repositories.

`--dry-run` switch can be helpful when testing your attribute converters.

You have to confirm your decision first as the migration process will write to the database. Whole operation is transactional and in case of errors it will rollback.

# Missing block definitions
If there are missing block definitions i.e. Form Block or Schedule Block in 2.2 you have an option to continue but migrated Landing Pages will come without those blocks. 

# How can I migrate my custom blocks?
For block types with custom storage you need to provide a dedicated converter but for simple blocks you can use `\EzSystems\EzPlatformPageMigration\Converter\AttributeConverter\DefaultConverter` as your service class.

Your service definition have to be tagged with 
```yaml
tags:
    - { name: 'ezplatform.fieldtype.ezlandingpage.migration.attribute.converter', block_type: 'my_block_type_identifier' }
``` 

Custom converters must implement `\EzSystems\EzPlatformPageMigration\Converter\AttributeConverter\ConverterInterface` interface. `convert()` method will parse XML `\DOMNode $node` and return an array of `\EzSystems\EzPlatformPageFieldType\FieldType\LandingPage\Model\Attribute` objects.