### PR TITLE
EZEE-2537: Exception "ZoneNotFoundException" no longer exists, but is used by Landing Page Migration script

### DIFF
--- a/src/lib/Exception/ZoneNotFoundException.php
+++ b/src/lib/Exception/ZoneNotFoundException.php
@@ -9,21 +9,16 @@ namespace EzSystems\EzPlatformPageMigration\Exception;
 use EzSystems\EzPlatformPageFieldType\FieldType\LandingPage\Definition\LayoutDefinition;
 use RuntimeException;
 
-/**
- * No zone found.
- */
 class ZoneNotFoundException extends RuntimeException
 {
     /**
-     * ZoneNotFoundException constructor.
-     *
      * @param string $zoneId
      * @param \EzSystems\EzPlatformPageFieldType\FieldType\LandingPage\Definition\LayoutDefinition $layout
      */
     public function __construct(string $zoneId, LayoutDefinition $layout)
     {
         parent::__construct(
-            'Zone with id: "' . $zoneId . '"" not found for layout: "' . $layout->getName() . '"", id: "' . $layout->getId() . '"'
+            sprintf('Zone with id: "%s" not found for layout: "%s", id: "%s"', $zoneId, $layout->getName(), $layout->getId())
         );
     }
 }

--- a/src/lib/Exception/ZoneNotFoundException.php
+++ b/src/lib/Exception/ZoneNotFoundException.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace EzSystems\EzPlatformPageMigration\Exception;
 
 use EzSystems\EzPlatformPageFieldType\FieldType\LandingPage\Definition\LayoutDefinition;
@@ -18,7 +20,12 @@ class ZoneNotFoundException extends RuntimeException
     public function __construct(string $zoneId, LayoutDefinition $layout)
     {
         parent::__construct(
-            sprintf('Zone with id: "%s" not found for layout: "%s", id: "%s"', $zoneId, $layout->getName(), $layout->getId())
+            sprintf(
+                'Zone with id: "%s" not found for layout: "%s", id: "%s"',
+                $zoneId,
+                $layout->getName(),
+                $layout->getId()
+            )
         );
     }
 }

--- a/src/lib/Exception/ZoneNotFoundException.php
+++ b/src/lib/Exception/ZoneNotFoundException.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPlatformPageMigration\Exception;
+
+use EzSystems\EzPlatformPageFieldType\FieldType\LandingPage\Definition\LayoutDefinition;
+use RuntimeException;
+
+/**
+ * No zone found.
+ */
+class ZoneNotFoundException extends RuntimeException
+{
+    /**
+     * ZoneNotFoundException constructor.
+     *
+     * @param string $zoneId
+     * @param \EzSystems\EzPlatformPageFieldType\FieldType\LandingPage\Definition\LayoutDefinition $layout
+     */
+    public function __construct(string $zoneId, LayoutDefinition $layout)
+    {
+        parent::__construct(
+            'Zone with id: "' . $zoneId . '"" not found for layout: "' . $layout->getName() . '"", id: "' . $layout->getId() . '"'
+        );
+    }
+}

--- a/src/lib/Page/PageFactory.php
+++ b/src/lib/Page/PageFactory.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformPageMigration\Page;
 
-use EzSystems\EzPlatformPageFieldType\Exception\ZoneNotFoundException;
 use EzSystems\EzPlatformPageFieldType\FieldType\LandingPage\Model\BlockValue;
 use EzSystems\EzPlatformPageFieldType\FieldType\LandingPage\Model\Page;
 use EzSystems\EzPlatformPageFieldType\FieldType\LandingPage\Model\Zone;
@@ -16,6 +15,7 @@ use EzSystems\EzPlatformPageFieldType\FieldType\Page\Block\Definition\BlockAttri
 use EzSystems\EzPlatformPageFieldType\FieldType\Page\Block\Definition\BlockDefinitionFactory;
 use EzSystems\EzPlatformPageFieldType\Registry\LayoutDefinitionRegistry;
 use EzSystems\EzPlatformPageMigration\Converter\AttributeConverter\XmlProcessor;
+use EzSystems\EzPlatformPageMigration\Exception\ZoneNotFoundException;
 use function in_array;
 
 class PageFactory
@@ -77,7 +77,7 @@ class PageFactory
             $zoneId = $zoneElement->getAttribute('id');
 
             if (!in_array($zoneId, $layoutDefinitionZoneIds, true) && !isset($layoutDefinitionZoneIds[$index])) {
-                throw new ZoneNotFoundException($layoutDefinition);
+                throw new ZoneNotFoundException($zoneId, $layoutDefinition);
             }
 
             $zoneName = $zoneElement->getAttribute('name');


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZEE-2537](https://jira.ez.no/browse/EZEE-2537)
| **Bug**| yes
| **Target version** | 1.0

This PR fixes missing 'ZoneNotFoundException' (as it was removed from `ezsystems/ezplatform-page-fieldtype` 1.1.0).