### PR TITLE
Convert all ezlandingpage fieldtypes to landingpage

### DIFF
--- a/src/bundle/Command/MigrateDataCommand.php
+++ b/src/bundle/Command/MigrateDataCommand.php
@@ -189,7 +189,14 @@ EOF
                 }
 
                 $languageCode = $field->languageCode;
-                $contentName = current($spiVersionInfo->names);
+
+                // Versions with STATUS_INTERNAL_DRAFT may not have name...
+                if ( $spiVersionInfo->names != null ) {
+                    $contentName = current($spiVersionInfo->names);
+                } else {
+                    $contentName = null;
+                }
+
                 $pageIdentifierString = sprintf(
                     '"%s" [contentId: %s, versionNo: %s, languageCode: %s]',
                     $contentName,

--- a/src/bundle/Command/MigrateDataCommand.php
+++ b/src/bundle/Command/MigrateDataCommand.php
@@ -234,8 +234,23 @@ EOF
      */
     protected function findLandingPages(): array
     {
-        $contentType = $this->contentTypeHandler->loadByIdentifier('landing_page');
-        $contentIds = $this->contentGateway->getContentIdsByContentTypeId($contentType->id);
+        $ezLandingPageContentTypes = [];
+        $contentTypeGroups = $this->contentTypeHandler->loadAllGroups();
+        foreach ($contentTypeGroups as $group) {
+            $contentTypes = $this->contentTypeHandler->loadContentTypes($group->id);
+            foreach ($contentTypes as $contentType) {
+                foreach ($contentType->fieldDefinitions as $fieldDefinition) {
+                    if ($fieldDefinition->fieldType === 'ezlandingpage') {
+                        $ezLandingPageContentTypes[] = $contentType;
+                    }
+                }
+            }
+        }
+
+        $contentIds = [];
+        foreach ($ezLandingPageContentTypes as $contentType) {
+            $contentIds = array_merge($contentIds, $this->contentGateway->getContentIdsByContentTypeId($contentType->id));
+        }
 
         return $contentIds;
     }

--- a/src/lib/Converter/AttributeConverter/XmlProcessor.php
+++ b/src/lib/Converter/AttributeConverter/XmlProcessor.php
@@ -10,18 +10,23 @@ namespace EzSystems\EzPlatformPageMigration\Converter\AttributeConverter;
 
 use DOMNode;
 use EzSystems\EzPlatformPageFieldType\FieldType\Page\Block\Definition\BlockDefinition;
+use Psr\Log\LoggerInterface as Logger;
 
 class XmlProcessor
 {
     /** @var \EzSystems\EzPlatformPageMigration\Converter\AttributeConverter\ConverterRegistry */
     private $registry;
 
+    /** @var Psr\Log\LoggerInterface */
+    private $logger;
+
     /**
      * @param \EzSystems\EzPlatformPageMigration\Converter\AttributeConverter\ConverterRegistry $registry
      */
-    public function __construct(ConverterRegistry $registry)
+    public function __construct(ConverterRegistry $registry, Logger $logger)
     {
         $this->registry = $registry;
+        $this->logger = $logger;
     }
 
     /**
@@ -35,6 +40,7 @@ class XmlProcessor
         $converter = $this->registry->getConverter($blockDefinition->getIdentifier());
 
         if (null === $converter) {
+            $this->logger->warning("No converter for BlockDefinition : {$blockDefinition->getIdentifier()}");
             return [];
         }
 


### PR DESCRIPTION
Previously, only the ContentType landing_page was migrated. Now it checks all ContentTypes...
PR also contains minor bugfixes and improvements